### PR TITLE
Added support for webpack 2 native es2015 modules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ function foo() {
 }
 
 function bar() {
-  return function() { 
+  return function() {
     // ...
   }
 }
@@ -65,6 +65,16 @@ npm install monkey-hot-loader
     ]
   }
 ```
+
+If you are using Webpack 2's native support of `import`, you must add `?sourceType=module` to the loader query string. Otherwise, you will encounter an error: `Module build failed: SyntaxError: 'import' and 'export' may appear only with 'sourceType: module'`. Any query string parameters are passed to the options for the [acorn parser](https://github.com/ternjs/acorn) used by this loader to find top level functions.
+```js
+  module: {
+    loaders: [
+      {test: /\.js$/, exclude: /node_modules/, loaders: ['monkey-hot?sourceType=module', 'babel'] },
+    ]
+  }
+```
+
 
 3a- For the frontend, you need to run the [Webpack Dev Server](http://webpack.github.io/docs/webpack-dev-server.html) to serve your assets. It will create a socketio server that your frontend uses to receive notifications. You can see an example of using the API in react-hot-loader's [same code](https://github.com/gaearon/react-hot-boilerplate/blob/master/server.js) to fire up the server. Make sure to load your assets from this server (i.e. `http://localhost:3000/js/bundle.js`).
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "https://github.com/jlongster/monkey-hot-loader.git"
   },
   "dependencies": {
-    "acorn": "^0.12.0",
-    "source-map": "^0.4.2"
+    "acorn": "^3.0.4",
+    "loader-utils": "^0.2.12",
+    "source-map": "^0.5.3"
   }
 }

--- a/patcher.js
+++ b/patcher.js
@@ -1,132 +1,141 @@
 if(module.hot) {
-  module.hot.accept(function(err) {
-    console.log('[HMR] Error accepting: ' + err);
-  });
+  (function() {
+    module.hot.accept(function(err) {
+      console.log('[HMR] Error accepting: ' + err);
+    });
 
-  var getEvalSource = function(func) {
-    var code = func.toString();
-    var m = code.match(/^function\s+__eval\s*\((.*)\)\s*\{([\s\S]*)\}$/i);
-    if(!m) {
-      return null;
-    }
-    var args = m[1];
-    var body = m[2];
-    var scope = {};
+    var getEvalSource = function(func) {
+      var code = func.toString();
+      var m = code.match(/^function\s+__eval\s*\((.*)\)\s*\{([\s\S]*)\}$/i);
+      if(!m) {
+        return null;
+      }
+      var args = m[1];
+      var body = m[2];
+      var scope = {};
 
-    if(args.trim()) {
-      args.split(',').forEach(function(arg) {
-        if(arg.indexOf('=') !== -1) {
-          var p = arg.split('=');
-          scope[p[0].trim()] = JSON.parse(p[1]);
-        }
-        else {
-          scope[arg.trim()] = undefined;
-        }
-      });
-    }
-
-    return { body: body, scope: scope };
-  }
-
-  var injectScope = function(scope, code) {
-    // Take an explicit scope object and inject it so that
-    // `code` runs in context of it
-    var injected = Object.keys(scope).map(function(binding) {
-      return 'var ' + binding + ' = evalScope.' + binding + ';'
-    }).join(' ');
-
-    // Update our scope object with any modifications
-    var extracted = Object.keys(scope).map(function(binding) {
-      return 'evalScope.' + binding + ' = ' + binding + ';';
-    }).join(' ');
-
-    return injected + code + extracted;
-  }
-
-  var bindings = __moduleBindings;
-
-  if(!module.hot.data) {
-    // First time loading. Try and patch something.
-    var patchedBindings = {};
-    var evalScope = {};
-
-    var moduleEvalWithScope = function(frame) {
-      // Update the scope to reflect only the values specified as
-      // arguments to the __eval function. Copy over values from the
-      // existing scope and ignore the rest.
-      Object.keys(evalScope).forEach(function(arg) {
-        if(arg in frame.scope) {
-          frame.scope[arg] = evalScope[arg];
-        }
-      });
-      evalScope = frame.scope;
-
-      var code = injectScope(evalScope, frame.body);
-      return eval(code);
-    }
-
-    var moduleEval = function(code) {
-      return eval(code);
-    }
-
-    bindings.forEach(function(binding) {
-      var f = eval(binding);
-
-      if(typeof f === 'function' && binding !== '__eval') {
-        var patched = function() {
-          if(patchedBindings[binding]) {
-            return patchedBindings[binding].apply(this, arguments);
+      if(args.trim()) {
+        args.split(',').forEach(function(arg) {
+          if(arg.indexOf('=') !== -1) {
+            var p = arg.split('=');
+            scope[p[0].trim()] = JSON.parse(p[1]);
           }
           else {
-            return f.apply(this, arguments);
+            scope[arg.trim()] = undefined;
           }
-        };
-        patched.prototype = f.prototype;
-
-        eval(binding + ' = patched;\n');
-
-        if(module.exports[binding]) {
-          module.exports[binding] = patched;
-        }
+        });
       }
-    });
 
-    module.hot.dispose(function(data) {
-      data.patchedBindings = patchedBindings;
-      data.moduleEval = moduleEval;
-      data.moduleEvalWithScope = moduleEvalWithScope;
-    });
-  }
-  else {
-    var patchedBindings = module.hot.data.patchedBindings;
-
-    bindings.forEach(function(binding) {
-      var f = eval(binding);
-
-      if(typeof f === 'function' && binding !== '__eval') {
-        // We need to reify the function in the original module so
-        // it references any of the original state. Strip the name
-        // and simply eval it.
-        var funcCode = (
-          '(' + f.toString().replace(/^function \w+\(/, 'function (') + ')'
-        );
-        patchedBindings[binding] = module.hot.data.moduleEval(funcCode);
-      }
-    });
-
-    if(typeof __eval === 'function') {
-      try {
-        module.hot.data.moduleEvalWithScope(getEvalSource(__eval));
-      }
-      catch(e) {
-        console.log('error evaling: ' + e);
-      }
+      return { body: body, scope: scope };
     }
 
-    module.hot.dispose(function(data) {
-      data.patchedBindings = patchedBindings;
-      data.moduleEval = module.hot.data.moduleEval;
-      data.moduleEvalWithScope = module.hot.data.moduleEvalWithScope;
-    });
-  }
+    var injectScope = function(scope, code) {
+      // Take an explicit scope object and inject it so that
+      // `code` runs in context of it
+      var injected = Object.keys(scope).map(function(binding) {
+        return 'var ' + binding + ' = evalScope.' + binding + ';'
+      }).join(' ');
+
+      // Update our scope object with any modifications
+      var extracted = Object.keys(scope).map(function(binding) {
+        return 'evalScope.' + binding + ' = ' + binding + ';';
+      }).join(' ');
+
+      return injected + code + extracted;
+    }
+
+    var bindings = __moduleBindings;
+
+    if(!module.hot.data) {
+      // First time loading. Try and patch something.
+      var patchedBindings = {};
+      var evalScope = {};
+
+      var moduleEvalWithScope = function(frame) {
+        // Update the scope to reflect only the values specified as
+        // arguments to the __eval function. Copy over values from the
+        // existing scope and ignore the rest.
+        Object.keys(evalScope).forEach(function(arg) {
+          if(arg in frame.scope) {
+            frame.scope[arg] = evalScope[arg];
+          }
+        });
+        evalScope = frame.scope;
+
+        var code = injectScope(evalScope, frame.body);
+        return eval(code);
+      }
+
+      var moduleEval = function(code) {
+        return eval(code);
+      }
+
+      var exportNames = Object.keys(module.exports);
+
+      bindings.forEach(function(binding) {
+        var f = eval(binding);
+
+        if(typeof f === 'function' && binding !== '__eval') {
+          var patched = function() {
+            if(patchedBindings[binding]) {
+              return patchedBindings[binding].apply(this, arguments);
+            }
+            else {
+              return f.apply(this, arguments);
+            }
+          };
+          patched.prototype = f.prototype;
+
+          eval(binding + ' = patched;\n');
+
+          exportNames.forEach(function(exportName) {
+            if (typeof module.exports[exportName] !== 'function') {
+              return;
+            }
+            if (module.exports[exportName].prototype === f.prototype) {
+              module.exports[exportName] = patched;
+            }
+          });
+        }
+      });
+
+      module.hot.dispose(function(data) {
+        data.patchedBindings = patchedBindings;
+        data.moduleEval = moduleEval;
+        data.moduleEvalWithScope = moduleEvalWithScope;
+      });
+    }
+    else {
+      var patchedBindings = module.hot.data.patchedBindings;
+
+      bindings.forEach(function(binding) {
+        var f = eval(binding);
+
+        if(typeof f === 'function' && binding !== '__eval') {
+          // We need to reify the function in the original module so
+          // it references any of the original state. Strip the name
+          // and simply eval it.
+          var funcCode = (
+            '(' + f.toString().replace(/^function \w+\(/, 'function (') + ')'
+          );
+          patchedBindings[binding] = module.hot.data.moduleEval(funcCode);
+        }
+      });
+
+      if(typeof __eval === 'function') {
+        try {
+          module.hot.data.moduleEvalWithScope(getEvalSource(__eval));
+        }
+        catch(e) {
+          console.log('error evaling: ' + e);
+        }
+      }
+
+      module.hot.dispose(function(data) {
+        data.patchedBindings = patchedBindings;
+        data.moduleEval = module.hot.data.moduleEval;
+        data.moduleEvalWithScope = module.hot.data.moduleEvalWithScope;
+      });
+    }
+  })();
 }


### PR DESCRIPTION
- Upgraded acorn parser to 3.x for es2015 support.
- Added use of the loader query string to send options to
  the parser.
- Changed updating module.exports with patched functions
  to compare all exports by function prototype as
  webpack uses arbitrary keys for named exports.
- Wrapped the patcher code in an IIFE to make sure
  it doesn't leak scope or overwrite inherited scope.

Unfortunately, adding the IIFE to patcher.js marks most of the lines of code as modified. The only actual code change is lines 73 and 91-98 of the new version which replaces lines 88-90 of the old version.

For each binding, it used to see if the binding name was in the module.exports and replaced that with the patched version. Now, it loops through all of the properties of modules.exports and sees if their function prototype matches the patched function's prototype. If so, it replaces it.

```
      var exportNames = Object.keys(module.exports); // line 73
      // ... inside bindings.forEach ... lines 91-98
          exportNames.forEach(function(exportName) {
            if (typeof module.exports[exportName] !== 'function') {
              return;
            }
            if (module.exports[exportName].prototype === f.prototype) {
              module.exports[exportName] = patched;
            }
          });
```

My branch can be tested by installing `git+https://github.com/rmarscher/monkey-hot-loader#webpack2-import` from npm. It is working great so far for my use case with webpack 2.1.0-beta.4. Thank you!
